### PR TITLE
Fixed grid.cr compilation errors

### DIFF
--- a/src/hedron/ui/grid.cr
+++ b/src/hedron/ui/grid.cr
@@ -10,7 +10,7 @@ module Hedron
     property align_x : Align
     property align_y : Align
 
-    def initialize(@size, @expand, @align); end
+    def initialize(@size, @expand, @align_x, @align_y); end
   end
 
   class Grid < Control

--- a/src/hedron/ui/grid.cr
+++ b/src/hedron/ui/grid.cr
@@ -10,12 +10,12 @@ module Hedron
     property align_x : Align
     property align_y : Align
 
-    def initialize(@size, @expand, @align_x, @align_y); end
+    def initialize(@size, @expand, @align_x : Align, @align_y : Align); end
   end
 
   class Grid < Control
     def initialize
-      @this = UI.new_grid
+      @this = ui_control(UI.new_grid)
     end
 
     def initialize(@this); end


### PR DESCRIPTION
align_x and align_y were being interpreted as symbols. They're now explicitly defined as Aligns.
Also,  @this is now casted to Control* using ui_control(), because the compiler was returning an error about it being a Grid pointer. 
grid_gallery.cr now successfully compiles on Linux.