### PR TITLE
Fix Entry#text and MultilineEntry#text methods

### DIFF
--- a/src/hedron/ui/entry.cr
+++ b/src/hedron/ui/entry.cr
@@ -42,7 +42,7 @@ module Hedron
     end
 
     def text : String
-      return UI.entry_text(to_unsafe)
+      return String.new(UI.entry_text(to_unsafe))
     end
 
     def text=(entry_text : String)

--- a/src/hedron/ui/multiline_entry.cr
+++ b/src/hedron/ui/multiline_entry.cr
@@ -46,7 +46,7 @@ module Hedron
     end
 
     def text : String
-      return UI.multiline_entry_text(to_unsafe)
+      return Strin.new(UI.multiline_entry_text(to_unsafe))
     end
 
     def text=(entry_text : String)


### PR DESCRIPTION
See #8. Char pointers needed to be used to create a new `String` in order to
compile.