### PR TITLE
Readme, Window.initialize, and MultilineEntry.text

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Hedron is under active development, so check back often!
 ```yaml
 dependencies:
   hedron:
-    github: Qwerp-Derp/hedron
+    github: hedron-crystal/hedron
     version: 0.1.0
 ```
 

--- a/src/hedron/application.cr
+++ b/src/hedron/application.cr
@@ -25,8 +25,6 @@ module Hedron
       unless ui_nil?(err)
         raise UIError.new("Error initializing UI: #{String.new(err)}")
       end
-
-      draw
     end
 
     # Start up the application.

--- a/src/hedron/ui/multiline_entry.cr
+++ b/src/hedron/ui/multiline_entry.cr
@@ -46,7 +46,7 @@ module Hedron
     end
 
     def text : String
-      return Strin.new(UI.multiline_entry_text(to_unsafe))
+      return String.new(UI.multiline_entry_text(to_unsafe))
     end
 
     def text=(entry_text : String)


### PR DESCRIPTION
The main thing is the `draw` method in `Window.initialize`. It is called right after initialization, and doesn't allow the user to pass any callbacks into the window.